### PR TITLE
Disable LimitChunkCountPlugin for node in dev mode

### DIFF
--- a/packages/razzle/config/createConfig.js
+++ b/packages/razzle/config/createConfig.js
@@ -304,11 +304,17 @@ module.exports = (
     config.plugins = [
       // We define environment variables that can be accessed globally in our
       new webpack.DefinePlugin(dotenv.stringified),
-      // Prevent creating multiple chunks for the server
-      new webpack.optimize.LimitChunkCountPlugin({
-        maxChunks: 1,
-      }),
     ];
+    // in dev mode emitting one huge server file on every save is very slow
+    if (!IS_DEV) {
+      config.plugins = [
+        ...config.plugins,
+        // Prevent creating multiple chunks for the server
+        new webpack.optimize.LimitChunkCountPlugin({
+          maxChunks: 1,
+        }),
+      ]
+    }
 
     config.entry = [paths.appServerIndexJs];
 


### PR DESCRIPTION
Currently I have a project that with LimitChunkCountPlugin takes this long for an update to come through in watch mode: (in this project this emits a 12 MB server.js)
```
✔ Client
  Compiled successfully in 660.10ms

✔ Server
  Compiled successfully in 8.24s
```

But if I disable LimitChunkCountPlugin I can get it all the way down to:

```
✔ Client
  Compiled successfully in 711.71ms

✔ Server
  Compiled successfully in 574.00ms
```


This also begs the question: What good does limiting server output to one file actually do?